### PR TITLE
fix: non-existent binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "build": "yarn-s b doc"
   },
   "bin": {
-    "doc": "build/bin/doc.js",
-    "doc-dev": "src/bin/index.js"
+    "doc": "build/bin/doc.js"
   },
   "man": "man/doc.1",
   "files": [


### PR DESCRIPTION
Documentary is unable to be installed by NPM due to "doc-dev" non-existent 

As I couldn't find this in use in the code-base, removing